### PR TITLE
Fix python3 shebang

### DIFF
--- a/tableparser.py
+++ b/tableparser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env pyhton3
+#!/usr/bin/env python3
 #FCKAFD
 from lxml import etree as et
 


### PR DESCRIPTION
This corrects a typo in the shebang so that this script can also be executed directly from the shell (instead of calling the python interpreter).